### PR TITLE
use fixtures to set inst level in tests

### DIFF
--- a/test/spell/core_test.clj
+++ b/test/spell/core_test.clj
@@ -1,8 +1,7 @@
 (ns spell.core-test
   (:require [clojure.test :as t]
             [spell.core :as s]))
-
-(s/inst!)
+(t/use-fixtures :once (fn [f] (s/inst!) (f) (s/unst!)))
 
 (t/deftest abbreviation-validation
   (t/is (s/valid? :int 42))


### PR DESCRIPTION
## Summary
- install and uninstall spell specs with a once fixture instead of a top-level call

## Testing
- `clojure -M:test -m clojure.test` *(fails: command not found)*
- `apt-get update` *(fails: repository signatures missing)*

------
https://chatgpt.com/codex/tasks/task_e_68989b193c7c832ca98a0d7cc2d56750