### PR TITLE
Handle nil instrumentation level in defnt

### DIFF
--- a/src/spell/core.clj
+++ b/src/spell/core.clj
@@ -64,7 +64,7 @@
                        in-specs# (store.inst/pull path# :in)
                        out-spec# (store.inst/pull path# :out)
                        level# (store.config/pull :level)
-                       err-f# (case level# :high u/fail! :low u/notify)]
+                       err-f# (case level# :high u/fail! :low u/notify nil)]
                    (when level#
                      (doall
                       (map (fn [arg# in-spec#]

--- a/test/spell/defnt_uninst_test.clj
+++ b/test/spell/defnt_uninst_test.clj
@@ -1,0 +1,10 @@
+(ns spell.defnt-uninst-test
+  (:require [clojure.test :as t]
+            [spell.core :as s]))
+
+(t/deftest defnt-executes-before-inst
+  (s/unst!)
+  (s/defnt foo [x] [:int :=> :int] (inc x))
+  (t/is (= 2 (foo 1)))
+  (s/inst!)
+  (s/unst!))


### PR DESCRIPTION
## Summary
- prevent err-f case from throwing when instrumentation level is nil
- add regression test ensuring defnt function runs before inst! is called

## Testing
- `clojure -X:test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b7db8e49bc832c87a6c3b9a6b34f1f