### PR TITLE
Add clj-kondo hook for tlet macro

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,2 +1,3 @@
-{:lint-as {spell.instrument/defnt
+{:hooks {:analyze-call {spell.instrument/tlet hooks.tlet/tlet}}
+ :lint-as {spell.instrument/defnt
            clojure.core/defn}}

--- a/.clj-kondo/hooks/tlet.clj
+++ b/.clj-kondo/hooks/tlet.clj
@@ -1,0 +1,14 @@
+(ns hooks.tlet
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn tlet [{:keys [node]}]
+  (let [[_ bindings & body] (:children node)
+        binding-children (:children bindings)
+        pairs (->> binding-children
+                   (partition 3)
+                   (mapcat (fn [[sym _spec val]] [sym val])))
+        new-bindings (api/vector-node pairs)
+        new-node (api/list-node (list* (api/token-node 'let)
+                                       new-bindings
+                                       body))]
+    {:node new-node}))

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@
 .cpcache
 .calva
 .nrepl-port
-.clj-kondo
+.clj-kondo/*
 !.clj-kondo/config.edn
+!.clj-kondo/hooks/
+!.clj-kondo/hooks/**


### PR DESCRIPTION
## Summary
- register analyze-call hook for `spell.instrument/tlet`
- implement `hooks.tlet/tlet` to rewrite binding triples so locals are detected
- track hook files in `.gitignore`

## Testing
- `clj -M:test` *(fails: command not found)*
- `clj-kondo --lint src` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ba8965ca64832c97006f52e88ce8d1