### PR TITLE
Add shadow-cljs configuration and alias

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,5 @@
 {:paths ["src"]
  :aliases {:test {:extra-paths ["test"]
                   :exec-fn clojure.test/run-tests
-                  :exec-args {:dirs ["test"]}}
-           :cljs {:extra-deps {org.clojure/clojurescript {:mvn/version "1.11.121"}}}
-           :shadow {:extra-deps {thheller/shadow-cljs {:mvn/version "2.28.3"}}
-                    :main-opts ["-m" "shadow.cljs.devtools.cli"]}}}
+                  :exec-args {:dirs ["test"]}}}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -2,5 +2,7 @@
  :aliases {:test {:extra-paths ["test"]
                   :exec-fn clojure.test/run-tests
                   :exec-args {:dirs ["test"]}}
-           :cljs {:extra-deps {org.clojure/clojurescript {:mvn/version "1.11.121"}}}}}
+           :cljs {:extra-deps {org.clojure/clojurescript {:mvn/version "1.11.121"}}}
+           :shadow {:extra-deps {thheller/shadow-cljs {:mvn/version "2.28.3"}}
+                    :main-opts ["-m" "shadow.cljs.devtools.cli"]}}}
 

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,4 +1,4 @@
 {:source-paths ["src" "test"]
- :dependencies []
+ :dependencies [[org.clojure/clojurescript "1.11.121"]]
  :builds {:app {:target :node-repl}}}
 

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,0 +1,4 @@
+{:source-paths ["src" "test"]
+ :dependencies []
+ :builds {:app {:target :node-repl}}}
+


### PR DESCRIPTION
## Summary
- add `:shadow` alias to `deps.edn` for shadow-cljs CLI
- create `shadow-cljs.edn` defining `:app` Node REPL build

## Testing
- `npm install shadow-cljs` *(fails: 403 Forbidden - GET https://registry.npmjs.org/shadow-cljs)*
- `clojure -M:test` *(fails: command not found: clojure)*

------
https://chatgpt.com/codex/tasks/task_e_68c1697a4a38832cb6ce5bcce906fd88